### PR TITLE
Check for NULL dataframe  when printing a dfSummary

### DIFF
--- a/R/print.summarytools.R
+++ b/R/print.summarytools.R
@@ -1151,7 +1151,7 @@ print.summarytools <- function(x, method = "pander", file = "", append = FALSE,
     
     sect_title[[1]] <- "Data Frame Summary  "
 
-    if ("Dataframe" %in% names(data_info)) {
+    if (("Dataframe" %in% names(data_info)) & (! is.null(data_info$Dataframe))) {
       sect_title[[2]] <- data_info$Dataframe
     }  else {
       sect_title[[2]] <- ""


### PR DESCRIPTION
Fixes issue #12 

If the dataframe used for dfSummary comes from a pipe, `data_info$Dataframe` is `NULL` and `sect_title` doesn't get populated properly. This can be fixed by checking for `NULL`.